### PR TITLE
We shouldn't be checking VIP functions

### DIFF
--- a/Wordpress-Rain-Extra-Strict/ruleset.xml
+++ b/Wordpress-Rain-Extra-Strict/ruleset.xml
@@ -5,7 +5,7 @@
 	<rule ref="WordPress-VIP">
 		<exclude name="WordPress.WP.I18n"/>
 		<exclude name="WordPress.VIP.AdminBarRemoval"/>
-		<exclude name="WordPress.VIP.RestrictedFunctions" />
+		<exclude name="WordPress.VIP.RestrictedFunctions"/>
 	</rule>
 
 	<rule ref="WordPress-Strict-Linux"/>

--- a/Wordpress-Rain-Extra-Strict/ruleset.xml
+++ b/Wordpress-Rain-Extra-Strict/ruleset.xml
@@ -5,6 +5,7 @@
 	<rule ref="WordPress-VIP">
 		<exclude name="WordPress.WP.I18n"/>
 		<exclude name="WordPress.VIP.AdminBarRemoval"/>
+		<exclude name="WordPress.VIP.RestrictedFunctions" />
 	</rule>
 
 	<rule ref="WordPress-Strict-Linux"/>


### PR DESCRIPTION
VIP functions are only available when using Wordpress VIP hosting.  We should not be checking for those restricted functions.   We are still including the rest of WordPress-VIP to use those as additional coding best practices.  
